### PR TITLE
GTS-327 - add option to add cookies via xml-file

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -93,6 +93,8 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->scalarNode('customFieldsPath')
                     ->end()
+                ->scalarNode('cookiesPath')
+                    ->end()
                 ->end();
 
         return $treeBuilder;

--- a/tests/Kernel/config/packages/shopware_app.yaml
+++ b/tests/Kernel/config/packages/shopware_app.yaml
@@ -33,3 +33,4 @@ shopware_app:
       - this
       - foo
   customFieldsPath: '../../path/to/customFields.xml'
+  cookiesPath: '../../path/to/cookies.xml'

--- a/tests/ShopwareAppBundleTest.php
+++ b/tests/ShopwareAppBundleTest.php
@@ -13,6 +13,7 @@ class ShopwareAppBundleTest extends KernelTestCase
         $appSecret = $this->getContainer()->getParameter('shopware_app.setup.secret');
         $permissions = $this->getContainer()->getParameter('shopware_app.permissions');
         $customFieldsPath = $this->getContainer()->getParameter('shopware_app.customFieldsPath');
+        $cookiesPath = $this->getContainer()->getParameter('shopware_app.cookiesPath');
 
         static::assertEquals([
             'version' => '1.0.0',
@@ -58,5 +59,6 @@ class ShopwareAppBundleTest extends KernelTestCase
         ], $permissions);
 
         static::assertEquals('../../path/to/customFields.xml', $customFieldsPath);
+        static::assertEquals('../../path/to/cookies.xml', $cookiesPath);
     }
 }


### PR DESCRIPTION
Due to the complexity of the cookie fields in the manifest, it is the easiest way to include a xml-file which is handled by the user. This would be the same procedere as with custom fields.