### PR TITLE
NTR - add option to set modules as main module

### DIFF
--- a/src/Attribute/Module.php
+++ b/src/Attribute/Module.php
@@ -8,12 +8,13 @@ use Symfony\Component\Routing\Annotation\Route;
 #[Attribute(Attribute::TARGET_METHOD)]
 class Module extends Route
 {
+    private const METHODS = ['GET'];
+
     /**
      * @param array<string, string> $label        array with language => translation
      * @param array|string          $data         data array managed by the Doctrine Annotations library or the path
      * @param array|string|null     $path
      * @param string[]              $requirements
-     * @param string[]|string       $methods
      * @param string[]|string       $schemes
      */
     public function __construct(
@@ -21,13 +22,13 @@ class Module extends Route
         private array $label,
         private string $parent,
         private int $position,
+        private bool $isMainModule = false,
         $data = [],
         $path = null,
         array $requirements = [],
         array $options = [],
         array $defaults = [],
         ?string $host = null,
-        $methods = [],
         $schemes = [],
         ?string $condition = null,
         ?int $priority = null,
@@ -37,7 +38,7 @@ class Module extends Route
         ?bool $stateless = null,
         ?string $env = null
     ) {
-        parent::__construct($data, $path, $name, $requirements, $options, $defaults, $host, $methods, $schemes, $condition, $priority, $locale, $format, $utf8, $stateless, $env);
+        parent::__construct($data, $path, $name, $requirements, $options, $defaults, $host, self::METHODS, $schemes, $condition, $priority, $locale, $format, $utf8, $stateless, $env);
     }
 
     public function getLabel(): array
@@ -68,5 +69,15 @@ class Module extends Route
     public function setPosition(int $position): void
     {
         $this->position = $position;
+    }
+
+    public function isMainModule(): bool
+    {
+        return $this->isMainModule;
+    }
+
+    public function setIsMainModule(bool $isMainModule): void
+    {
+        $this->isMainModule = $isMainModule;
     }
 }

--- a/tests/Attribute/ModuleTest.php
+++ b/tests/Attribute/ModuleTest.php
@@ -8,7 +8,7 @@ use Shopware\AppBundle\Attribute\Module;
 
 class ModuleTest extends TestCase
 {
-    #[Module(path: '/my/module', name: 'my_module', label: ['default' => 'my module', 'de-de' => 'mein Modul'], parent: 'parent', position: 30)]
+    #[Module(name: 'my_module', label: ['default' => 'my module', 'de-de' => 'mein Modul'], parent: 'parent', position: 30, isMainModule: false, path: '/my/module')]
     public function testModuleAttribute(): void
     {
         $reflectionClass = new ReflectionClass($this);
@@ -25,6 +25,7 @@ class ModuleTest extends TestCase
             ],
             'parent' => 'parent',
             'position' => 30,
+            'isMainModule' => false,
         ]);
     }
 }


### PR DESCRIPTION
To set a module also as a main-module, you can simply set the argument `isMainModule = true`.  
If you want to use different routes but the same method you can also add both attributes to the method with different names for the route. 