### PR TITLE
Support shops installed in subdomains

### DIFF
--- a/src/Client/GuzzleClientFactory.php
+++ b/src/Client/GuzzleClientFactory.php
@@ -10,10 +10,20 @@ class GuzzleClientFactory implements ClientFactoryInterface
     public function createClient(ShopEntity $shop): ShopClient
     {
         return new ShopClient(
-            new Client([
-                'base_uri' => $shop->getUrl(),
-            ]),
+            new Client($this->getClientConfiguration($shop)),
             $shop
         );
+    }
+
+    protected function getClientConfiguration(ShopEntity $shop): array
+    {
+        return [
+            'base_uri' => $this->ensureTrailingSlashInUrl($shop->getUrl()),
+        ];
+    }
+
+    private function ensureTrailingSlashInURL(string $shopUrl): string
+    {
+        return str_ends_with($shopUrl, '/') ? $shopUrl : $shopUrl . '/';
     }
 }

--- a/src/Client/ShopClient.php
+++ b/src/Client/ShopClient.php
@@ -13,7 +13,7 @@ use Shopware\AppBundle\Shop\ShopEntity;
 
 class ShopClient implements ClientInterface
 {
-    private const AUTHENTICATION_ROUTE = '/api/oauth/token';
+    private const AUTHENTICATION_ROUTE = 'api/oauth/token';
 
     private const AUTH_HEADER = 'Authorization';
 

--- a/tests/Client/GuzzleClientFactoryTest.php
+++ b/tests/Client/GuzzleClientFactoryTest.php
@@ -48,6 +48,30 @@ class GuzzleClientFactoryTest extends TestCase
         static::assertEquals('/sub/domain/api/search/product', $request->getRequestTarget());
     }
 
+    public function testClientFactoryDoesNotAddDoubleSlash(): void
+    {
+        $clientFactory = new MockedGuzzleClientFactory();
+
+        $client = $clientFactory->createClient(new ShopEntity(
+            'shopId',
+            'https://shop.domain/sub/domain/',
+            'secret',
+            'abcd',
+            'efgh',
+        ));
+
+        $clientFactory->getMockHandler()->append(
+            $this->getAuthResponse(),
+            new Response(200, [], '[]'),
+        );
+
+        $client->sendRequest(new Request('POST', 'api/search/product', [], '{}'));
+
+        $request = $clientFactory->getMockHandler()->getLastRequest();
+
+        static::assertEquals('/sub/domain/api/search/product', $request->getRequestTarget());
+    }
+
     private function getAuthResponse(): ResponseInterface
     {
         return new Response(

--- a/tests/Client/GuzzleClientFactoryTest.php
+++ b/tests/Client/GuzzleClientFactoryTest.php
@@ -2,7 +2,10 @@
 
 namespace Shopware\AppBundle\Test\Client;
 
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
 use Shopware\AppBundle\Client\GuzzleClientFactory;
 use Shopware\AppBundle\Client\ShopClient;
 use Shopware\AppBundle\Shop\ShopEntity;
@@ -18,6 +21,43 @@ class GuzzleClientFactoryTest extends TestCase
             $clientFactory->createClient(
                 new ShopEntity('shopId', 'shopUrl', 'secret')
             )
+        );
+    }
+
+    public function testClientRespectsSubDomains(): void
+    {
+        $clientFactory = new MockedGuzzleClientFactory();
+
+        $client = $clientFactory->createClient(new ShopEntity(
+            'shopId',
+            'https://shop.domain/sub/domain',
+            'secret',
+            'abcd',
+            'efgh',
+        ));
+
+        $clientFactory->getMockHandler()->append(
+            $this->getAuthResponse(),
+            new Response(200, [], '[]'),
+        );
+
+        $client->sendRequest(new Request('POST', 'api/search/product', [], '{}'));
+
+        $request = $clientFactory->getMockHandler()->getLastRequest();
+
+        static::assertEquals('/sub/domain/api/search/product', $request->getRequestTarget());
+    }
+
+    private function getAuthResponse(): ResponseInterface
+    {
+        return new Response(
+            200,
+            ['content-type' => 'application/json'],
+            json_encode([
+                'token_type' => 'Bearer',
+                'expires_in' => 600,
+                'access_token' => 'shopware-access-token',
+            ])
         );
     }
 }

--- a/tests/Client/MockedGuzzleClientFactory.php
+++ b/tests/Client/MockedGuzzleClientFactory.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\AppBundle\Test\Client;
+
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use Shopware\AppBundle\Client\GuzzleClientFactory;
+use Shopware\AppBundle\Shop\ShopEntity;
+
+class MockedGuzzleClientFactory extends GuzzleClientFactory
+{
+    private $mockHandler;
+
+    private $history;
+
+    public function __construct()
+    {
+        $this->mockHandler = new MockHandler();
+        $this->history = [];
+    }
+
+    public function getMockHandler(): MockHandler
+    {
+        return $this->mockHandler;
+    }
+
+    public function getHistory(): array
+    {
+        return $this->history;
+    }
+
+    protected function getClientConfiguration(ShopEntity $shop): array
+    {
+        $configuration = parent::getClientConfiguration($shop);
+        $handlerStack = HandlerStack::create($this->mockHandler);
+        $handlerStack->push(Middleware::history($this->history));
+
+        $configuration['handler'] = $handlerStack;
+
+        return $configuration;
+    }
+}


### PR DESCRIPTION
We made a mistake when concatenating the base URL with request URIs. This made it impossible to register shops that were installed in a subdomain (e.g. `https://my.domain/shop/en`)

According to the Guzzle documentation (https://docs.guzzlephp.org/en/stable/quickstart.html) the path component of the base URL (in our case `/shop/en`) is preserved if and only if it ends with a slash and the request URI is relative.